### PR TITLE
Carriers and cap transfer

### DIFF
--- a/GameInfo/AbilityCapTransferAugoror.entity
+++ b/GameInfo/AbilityCapTransferAugoror.entity
@@ -50,10 +50,10 @@ ignoreNonCombatShipsForAutoCastTarget TRUE
 onlyAutoCastWhenDamageTakenExceedsPerc 0.000000
 useCostType "AntiMatter"
 antiMatterCost
-	Level:0 91.000000
-	Level:1 91.000000
-	Level:2 91.000000
-	Level:3 91.000000
+	Level:0 0.000000
+	Level:1 0.000000
+	Level:2 0.000000
+	Level:3 0.000000
 cooldownTime
 	Level:0 5.000000
 	Level:1 5.000000

--- a/GameInfo/AbilityCapTransferTriage.entity
+++ b/GameInfo/AbilityCapTransferTriage.entity
@@ -50,10 +50,10 @@ ignoreNonCombatShipsForAutoCastTarget TRUE
 onlyAutoCastWhenDamageTakenExceedsPerc 0.000000
 useCostType "AntiMatter"
 antiMatterCost
-	Level:0 1519.000000
-	Level:1 1473.000000
-	Level:2 1428.000000
-	Level:3 1382.000000
+	Level:0 0.000000
+	Level:1 0.000000
+	Level:2 0.000000
+	Level:3 0.000000
 cooldownTime
 	Level:0 20.000000
 	Level:1 20.000000

--- a/GameInfo/BuffCapTransferAugororTarget.entity
+++ b/GameInfo/BuffCapTransferAugororTarget.entity
@@ -13,10 +13,10 @@ instantAction
 	instantActionTriggerType "OnDelay"
 	delayTime 0.000000
 	antiMatter
-		Level:0 140.000000
-		Level:1 140.000000
-		Level:2 140.000000
-		Level:3 140.000000
+		Level:0 49.000000
+		Level:1 49.000000
+		Level:2 49.000000
+		Level:3 49.000000
 numPeriodicActions 0
 numOverTimeActions 0
 numEntityModifiers 0

--- a/GameInfo/BuffCapTransferTriageTarget.entity
+++ b/GameInfo/BuffCapTransferTriageTarget.entity
@@ -13,10 +13,10 @@ instantAction
 	instantActionTriggerType "OnDelay"
 	delayTime 0.000000
 	antiMatter
-		Level:0 1625.000000
-		Level:1 1625.000000
-		Level:2 1625.000000
-		Level:3 1625.000000
+		Level:0 106.000000
+		Level:1 152.000000
+		Level:2 197.000000
+		Level:3 243.000000
 numPeriodicActions 0
 numOverTimeActions 0
 numEntityModifiers 0

--- a/GameInfo/Caldari_Ship_Carrier_Chimera.entity
+++ b/GameInfo/Caldari_Ship_Carrier_Chimera.entity
@@ -2,7 +2,7 @@
 entityType "CapitalShip"
 ability:0 "AbilityFighterControlUnit"
 ability:1 "AbilityPLASMASmartbomb"
-ability:2 "AbilityArmorRepairerCapital"
+ability:2 "AbilityShieldBoosterCapital"
 ability:3 "AbilityCarrier"
 ability:4 ""
 defaultAutoAttackRange "GravityWell"

--- a/GameInfo/Minmatar_Ship_Carrier_Nidhoggur.entity
+++ b/GameInfo/Minmatar_Ship_Carrier_Nidhoggur.entity
@@ -2,7 +2,7 @@
 entityType "CapitalShip"
 ability:0 "AbilityFighterControlUnit"
 ability:1 "AbilityPLASMASmartbomb"
-ability:2 "AbilityArmorRepairerCapital"
+ability:2 "AbilityShieldBoosterCapital"
 ability:3 "AbilityCarrier"
 ability:4 ""
 defaultAutoAttackRange "GravityWell"


### PR DESCRIPTION
Nidhoggur and Chimera now have Shield Boosters instead of Armor Repairers, Cap transfers changed so that they give free cap instead of giving more than they take (there is no check for capacitor amount).